### PR TITLE
Update boot2docker rc builder to work for 1.11.0-rc1

### DIFF
--- a/dsl/tianon/boot2docker.groovy
+++ b/dsl/tianon/boot2docker.groovy
@@ -16,7 +16,7 @@ docker run --rm boot2docker/boot2docker > boot2docker.iso
 git-set-mtimes
 
 testDocker="$(curl -fsSL 'http://test.docker.com.s3.amazonaws.com/latest')"
-testDockerSha256="$(curl -fsSL "http://test.docker.com.s3.amazonaws.com/builds/Linux/x86_64/docker-${testDocker}.sha256" | cut -d' ' -f1)"
+testDockerSha256="$(curl -fsSL "http://test.docker.com.s3.amazonaws.com/builds/Linux/x86_64/docker-${testDocker}.tgz.sha256" | cut -d' ' -f1)"
 
 touch "version-TEST-$testDocker"
 
@@ -27,9 +27,10 @@ ENV TEST_DOCKER_VERSION ${testDocker}
 ENV TEST_DOCKER_SHA256 ${testDockerSha256}
 
 RUN set -x \\
-	&& curl -fsSL http://test.docker.com.s3.amazonaws.com/builds/Linux/x86_64/docker-\\$TEST_DOCKER_VERSION -o \\$ROOTFS/usr/local/bin/docker \\
-	&& echo "\\${TEST_DOCKER_SHA256} *\\$ROOTFS/usr/local/bin/docker" | sha256sum -c - \\
-	&& chmod +x \\$ROOTFS/usr/local/bin/docker \\
+	&& curl -fsSL http://test.docker.com.s3.amazonaws.com/builds/Linux/x86_64/docker-\\$TEST_DOCKER_VERSION.tgz -o \\$ROOTFS/tmp/dockerbin.tgz \\
+	&& echo "\\${TEST_DOCKER_SHA256} *\\$ROOTFS/tmp/dockerbin.tgz" | sha256sum -c - \\
+	&& tar zxvf \\$ROOTFS/tmp/dockerbin.tgz -C \\$ROOTFS/ \\
+	&& rm \\$ROOTFS/tmp/dockerbin.tgz \\
 	&& \\$ROOTFS/usr/local/bin/docker -v
 
 RUN \\$ROOTFS/usr/local/bin/docker -v | sed -r 's/.* version ([^ ,]+).*/\\1/' > \\$ROOTFS/etc/version \\


### PR DESCRIPTION
Duplicate changes from https://github.com/boot2docker/boot2docker/pull/1153
